### PR TITLE
Remove src/migrations class map

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,9 +13,6 @@
         "illuminate/support": "4.2.*"
     },
     "autoload": {
-        "classmap": [
-            "src/migrations"
-        ],
         "psr-0": {
             "Braunson\\LaravelHTML5Forms\\": "src/"
         }


### PR DESCRIPTION
This was causing an install failure within laravel

```
[RuntimeException]
  Could not scan for classes inside "/projects/laravel/vendor/braunson/laravel-html5-forms/src/migrations" which does not appear to be a file nor a folder
```
