### PR TITLE
Fixed required composer version for iluminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "^4.2.*"
+        "illuminate/support": "4.2.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
This is fix for your issue #10 

Your package was not able to install `illuminate/support` package  so i fixed way you require version 4.2.

